### PR TITLE
fix: 400 error on watch update — clean empty strings before submit

### DIFF
--- a/src/web/src/components/common/WatchForm.vue
+++ b/src/web/src/components/common/WatchForm.vue
@@ -336,7 +336,20 @@ function removePhoto() {
 }
 
 function handleFormSubmit() {
-  emit('submit', formData, photoFile.value || undefined)
+  // Clean empty strings to null/undefined for API validation (e.g. [Url] rejects "")
+  const cleaned: Record<string, any> = {}
+  for (const [key, value] of Object.entries(formData)) {
+    if (value === '' || value === null) {
+      cleaned[key] = undefined
+    } else {
+      cleaned[key] = value
+    }
+  }
+  // Required fields must always be present
+  cleaned.brand = formData.brand
+  cleaned.model = formData.model
+  cleaned.movementType = formData.movementType
+  emit('submit', cleaned as CreateWatch, photoFile.value || undefined)
 }
 </script>
 

--- a/src/web/src/pages/WatchDetailPage.vue
+++ b/src/web/src/pages/WatchDetailPage.vue
@@ -238,9 +238,25 @@ async function handlePurchase() {
   if (!watch.value || !confirm('Move this watch from your wish list to your collection?')) return
   purchasing.value = true
   try {
-    await updateWatch(watch.value.id, { ...watch.value, isWishList: false })
-    router.push(`/watches/${watch.value.id}`)
-    watch.value = await getWatch(watch.value.id)
+    const w = watch.value
+    await updateWatch(w.id, {
+      brand: w.brand,
+      model: w.model,
+      movementType: w.movementType,
+      caseSizeMm: w.caseSizeMm,
+      bandType: w.bandType,
+      bandColor: w.bandColor,
+      purchaseDate: w.purchaseDate,
+      purchasePrice: w.purchasePrice,
+      notes: w.notes,
+      crystalType: w.crystalType,
+      dialColor: w.dialColor,
+      waterResistance: w.waterResistance,
+      linkUrl: w.linkUrl,
+      linkText: w.linkText,
+      isWishList: false,
+    })
+    watch.value = await getWatch(w.id)
   } finally {
     purchasing.value = false
   }


### PR DESCRIPTION
- Empty string values (e.g. linkUrl='') now sent as undefined/null to avoid API validation failures ([Url] rejects empty strings)
- handlePurchase sends only UpdateWatch fields (not full Watch object which includes id, imageUrls, timesWorn etc. that API rejects)
- Required fields (brand, model, movementType) always preserved